### PR TITLE
Fix `apply` not working for relative paths

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -159,7 +159,7 @@ pub fn process_path(path: Utf8PathBuf) -> Result<Vec<Utf8PathBuf>> {
                 .read_dir_utf8()?
                 .filter_map(Result::ok)
                 .filter(|entry| entry.path().extension().map_or(false, |ext| ext == "yml" || ext == "yaml"))
-                .map(|entry| path.join(entry.path()))
+                .map(|entry| entry.into_path())
                 .collect::<Vec<Utf8PathBuf>>();
 
             files.sort();

--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -150,16 +150,22 @@ fn kill_process_by_name(name: &str) {
     }
 }
 
+fn is_yaml(path: &Utf8PathBuf) -> bool {
+    path.extension()
+        .map(|ext| ext.to_ascii_lowercase())
+        .map(|ext| ext == "yml" || ext == "yaml")
+        .unwrap_or(false)
+}
+
 pub fn process_path(path: Utf8PathBuf) -> Result<Vec<Utf8PathBuf>> {
-    //
     match path {
         path if path.is_file() => Ok(vec![path]),
         path if path.is_dir() => {
             let mut files = path
                 .read_dir_utf8()?
                 .filter_map(Result::ok)
-                .filter(|entry| entry.path().extension().map_or(false, |ext| ext == "yml" || ext == "yaml"))
                 .map(|entry| entry.into_path())
+                .filter(is_yaml)
                 .collect::<Vec<Utf8PathBuf>>();
 
             files.sort();


### PR DESCRIPTION
This PR fixes a bug where trying to use `apply` with a relative path to a directory of YAML files causes a panic:
```
 macos-defaults apply data/macos-defaults/
Error:
   0: Failed to read bytes from path data/macos-defaults/data/macos-defaults/accessibility.yaml.
   1: No such file or directory (os error 2)

Location:
   src/main.rs:93

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

The issue is caused here: https://github.com/dsully/macos-defaults/blob/7ec24bc20ee15fd5ec95827440e939e608246795/src/cmd/apply.rs#L158-L163

Calling `entry.path()` gets a complete path to each entry (e.g. `data/macos-defaults/accessibility.yaml`), which is then erroneously joined to the path of its parent directory (`data/macos-defaults/`), resulting in a non-existent path like `data/macos-defaults/data/macos-defaults/accessibility.yaml`. This incidentally works when the path is absolute, because in that case [the new path simply replaces the old one](https://docs.rs/camino/latest/camino/struct.Utf8PathBuf.html#method.push)).

This PR changes the implementation to avoid improperly appending the string, and function as intended.
```
macos-defaults apply data/macos-defaults/
  ▶ Accessibility
  ▶ Activity Monitor
  ▶ Audio & Sound
  ▶ Calendar
  ▶ Contacts
  ▶ Displays
  ▶ Dock
  ▶ Finder
  ▶ Globals
  ▶ Keyboard
  ▶ Mac App Store
  ▶ Mail
  ▶ Menu Bar
  ▶ Messages
  ▶ Photos & Image Capture
  ▶ Safari
  ▶ Security
  ▶ Siri
  ▶ Spotlight
  ▶ Terminal
  ▶ Text Edit
  ▶ Time Machine
  ▶ Trackpad
  ▶ Trackpad Currenthost
  ▶ Xcode
  ```