### PR TITLE
Feature: allow ellipsis "..." replacement in deeply nested dictionaries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,45 @@ You may also use full paths to `.plist` files instead of domain names.
 
 This is the only way to set values in /Library/Preferences/
 
+### Dictionary merge syntax
+
+If a dictionary property contains the key `...`, it will be merged with the previous value of that dictionary. Keys before the `...` take precendece, then the old keys, then keys after it.
+
+For example, the following config:
+```yaml
+data:
+  com.apple.finder:
+    DesktopViewSettings:
+      IconViewSettings:
+        labelOnBottom: false # item info on right
+        ...: {}
+        iconSize: 80.0
+
+```
+Will perform the following actions:
+* Set `DesktopViewSettings:IconViewSettings:labelOnBottom` to true,
+* Set `DesktopViewSettings:IconViewSettings:iconSize` to 80.0, but only if it doesn't already exist.  
+* Keep all other keys on `IconViewSettings` as-is.
+
+If `...` isn't present, the dictionary will be fully overwritten, and keys not specified will be deleted.
+
+### Array merge syntax
+
+If an array contains the element `"..."`, it will be replaced by the contents of the existing array. Arrays are treated like sets, so elements which already exist will not be added.
+
+For example, the following config:
+
+```yaml
+data:
+  org.my.test:
+    aDict:
+    };
+        anArray: ["foo", "...", "bar"]
+```
+
+* Prepend `"foo"` to `aDict:anArray`, if it doesn't already contain `"foo"`.
+* Append `"bar"` to `aDict:anArray`, if it doesn't already contain `"bar"`.
+
 ## Examples
 
 See my [dotfiles](https://github.com/dsully/dotfiles/tree/main/.data/macos-defaults) repository.

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -382,7 +382,15 @@ fn replace_ellipsis_array(new_array: &mut Vec<Value>, old_value: Option<&Value>)
 /// You end up with: [<new contents before ...>, <old contents>, <new contents after ...>]
 /// But any duplicates between old and new values are removed, with the first value taking
 /// precedence.
+///
+/// If an entry of this element is a dictionary or an array, this applies recursively.
 fn replace_ellipsis_dict(new_dict: &mut Dictionary, old_value: Option<&Value>) {
+    // recursively call replace elipses on entry values, with their corresponding value from the old dictionary
+    for (key, child_value) in &mut *new_dict {
+        let old_child_value = old_value.and_then(Value::as_dictionary).and_then(|old_dict| old_dict.get(key));
+        replace_ellipsis(child_value, old_child_value);
+    }
+
     if !new_dict.contains_key(ELLIPSIS) {
         trace!("New value doesn't contain ellipsis, skipping ellipsis replacement...");
         return;


### PR DESCRIPTION
This PR changes the behavior of the function write_defaults_values to recursively apply the "replace ellipsis" operation to all dictionaries and arrays which are children of dictionaries.

# Issue description

I have a Finder yaml configuration like this:
```yaml
---
description: Finder
kill: ["Finder"]
data:
  com.apple.finder:
    DesktopViewSettings:
      IconViewSettings:
        arrangeBy: "kind"
        gridSpacing: 100.0
        iconSize: 80.0
        labelOnBottom: false # item info on right
        showItemInfo: true
```

My desired end result looks something like this:
```
$ defaults read com.apple.finder DesktopViewSettings
{
    IconViewSettings =     {
        arrangeBy = kind;
        axTextSize = 12;
        backgroundColorBlue = 1;
        backgroundColorGreen = 1;
        backgroundColorRed = 1;
        backgroundType = 0;
        gridOffsetX = 0;
        gridOffsetY = 0;
        gridSpacing = 100;
        iconSize = 80;
        labelOnBottom = 0;
        showIconPreview = 1;
        showItemInfo = 1;
        textSize = 12;
        viewOptionsVersion = 1;
    };
}
```

Unfortunately, the IconViewSettings dict ends up clobbering the existing one and removing the other properties. Upon restarting, Finder.app seems to detect the missing properties, and blanks the entire dictionary. I hoped to remedy this using the `"..."` syntax to merge my new keys on top of the defaults, like this:

```yaml
---
description: Finder
kill: ["Finder"]
data:
  com.apple.finder:
    DesktopViewSettings:
      IconViewSettings:
        arrangeBy: "kind"
        gridSpacing: 100.0
        iconSize: 80.0
        labelOnBottom: false # item info on right
        showItemInfo: true
        "...": {}
```

But this failed, because the current implementation only seems to call `replace_ellipsis_dict` on top-level children of the domain key, and not on nested objects.

# Solution

My commit adds a loop to replace_ellipsis_dict which tries to recursively invoke either `replace_ellipisis` (array or dict) on every entry within the dict. I didn't add corresponding functionality to arrays, as I couldn't think of a sane way for that to work. That might create some oddities in hypothetical cases but hopefully will never end up mattering in real world use.

I admit that haven't thoroughly tested this code for regressions. I think the `"..."` feature should have more unit tests and documentation. I wonder how feasible it would be to extend the syntax further, with something like https://docs.rs/yaml-merge-keys/latest/yaml_merge_keys/ .