### PR TITLE
Feature: merge dictionaries by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,31 +90,36 @@ data:
     ABIncludePhotosInVCard: true
 ```
 
-You may also use full paths to `.plist` files instead of domain names.
+You may also use full paths to `.plist` files instead of domain names. This is the only way to set values in /Library/Preferences/.
 
-This is the only way to set values in /Library/Preferences/
+### Overwrite syntax
 
-### Dictionary merge syntax
+By default, the YAML will be merged against existing domains.
 
-If a dictionary property contains the key `...`, it will be merged with the previous value of that dictionary. Keys before the `...` take precendece, then the old keys, then keys after it.
-
-For example, the following config:
+For example, the following config will leave any other keys on `DesktopViewSettings:IconViewSettings` untouched:
 ```yaml
 data:
   com.apple.finder:
     DesktopViewSettings:
       IconViewSettings:
         labelOnBottom: false # item info on right
-        ...: {}
         iconSize: 80.0
-
 ```
-Will perform the following actions:
-* Set `DesktopViewSettings:IconViewSettings:labelOnBottom` to true,
-* Set `DesktopViewSettings:IconViewSettings:iconSize` to 80.0, but only if it doesn't already exist.  
-* Keep all other keys on `IconViewSettings` as-is.
 
-If `...` isn't present, the dictionary will be fully overwritten, and keys not specified will be deleted.
+This can be overridden by adding the key `"!"` to a dict, which will delete any keys which are not specified. For example, the following config will delete all properties on the com.apple.finder domain except for DesktopViewSettings, and likewise, all properties on `IconViewSettings` except those specified.
+
+```yaml
+data:
+  com.apple.finder:
+    "!": {} # overwrite!
+    DesktopViewSettings:
+      IconViewSettings:
+        "!": {} # overwrite!
+        labelOnBottom: false # item info on right
+        iconSize: 80.0
+```
+
+This feature has the potential to erase important settings, so exercise caution. Running `macos-defaults apply` creates a backup of each modified plist at, for example, `~/Library/Preferences/com.apple.finder.plist.prev`.
 
 ### Array merge syntax
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,45 @@ You may also use full paths to `.plist` files instead of domain names.
 
 This is the only way to set values in /Library/Preferences/
 
+### Dictionary merge syntax
+
+If a dictionary property contains the key `...`, it will be merged with the previous value of that dictionary. Keys before the `...` take precendece, then the old keys, then keys after it.
+
+For example, the following config:
+```yaml
+data:
+  com.apple.finder:
+    DesktopViewSettings:
+      IconViewSettings:
+        labelOnBottom: false # item info on right
+        ...: {}
+        iconSize: 80.0
+
+```
+Will perform the following actions:
+* Set `DesktopViewSettings:IconViewSettings:labelOnBottom` to true,
+* Set `DesktopViewSettings:IconViewSettings:iconSize` to 80.0, but only if it doesn't already exist.  
+* Keep all other keys on `IconViewSettings` as-is.
+
+If `...` isn't present, the dictionary will be fully overwritten, and keys not specified will be deleted.
+
+### Array merge syntax
+
+If an array contains the element `"..."`, it will be replaced by the contents of the existing array. Arrays are treated like sets, so elements which already exist will not be added.
+
+For example, the following config:
+
+```yaml
+data:
+  org.my.test:
+    aDict:
+    };
+        anArray: ["foo", "...", "bar"]
+```
+
+* Prepend `"foo"` to `aDict:anArray`, if it doesn't already contain `"foo"`.
+* Append `"bar"` to `aDict:anArray`, if it doesn't already contain `"bar"`.
+
 ## Examples
 
 See my [dotfiles](https://github.com/dsully/dotfiles/tree/main/.data/macos-defaults) repository.

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -405,6 +405,9 @@ fn deep_merge_dictionaries(new_value: &mut Value, old_value: Option<&Value>) {
         trace!("New value is an empty dictionary. Skipping merge...");
         return;
     }
+    // the "..." key is no longer used, and its merging behavior is performed by default. ignore it, for compatibility with older YAML.
+    new_dict.remove(ELLIPSIS);
+
     let Some(old_dict) = old_value.and_then(plist::Value::as_dictionary) else {
         trace!("Old value wasn't a dict. Skipping merge...");
         return;
@@ -417,7 +420,6 @@ fn deep_merge_dictionaries(new_value: &mut Value, old_value: Option<&Value>) {
         let old_child_value = old_dict.get(key);
         merge_value(new_child_value, old_child_value);
     }
-    
 
     if new_dict.contains_key(BANG) {
         trace!("Dictionary contains key '!'. Skipping merge...");

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -382,7 +382,15 @@ fn replace_ellipsis_array(new_array: &mut Vec<Value>, old_value: Option<&Value>)
 /// You end up with: [<new contents before ...>, <old contents>, <new contents after ...>]
 /// But any duplicates between old and new values are removed, with the first value taking
 /// precedence.
+///
+/// If an entry of this element is a dictionary or an array, this applies recursively.
 fn replace_ellipsis_dict(new_dict: &mut Dictionary, old_value: Option<&Value>) {
+    // recursively call replace elipses on entry values, with their corresponding value from the old dictionary
+    for (key, child_value) in &mut *new_dict {
+        let old_child_value = old_value.and_then(Value::as_dictionary).and_then(|old_dict| old_dict.get(key));
+        replace_ellipsis(child_value, old_child_value);
+    }
+
     if !new_dict.contains_key(ELLIPSIS) {
         trace!("New value doesn't contain ellipsis, skipping ellipsis replacement...");
         return;


### PR DESCRIPTION
This PR supercedes #2, and adds the functionality described by my comment here: https://github.com/dsully/macos-defaults/pull/2#issuecomment-2126169777

All dictionaries are now deeply merged against existing dictionary properties, which I think is a sane default. They should now act as though they were "subdomains" (which don't actually exist in Defaults), and follow the same rules as top level properties.

This adds a new key `"!"` which replaces the `"..."` key on dicts (still works as before on arrays), and explicitly opts *out* of preserving the existing keys on that specific dictionary (not for its children). This works on domains as well.

In theory, this does break the ability to specify "soft" settings, which are only applied if another such value doesn't already exist. However, this is an extremely niche and advanced feature, which I can't imagine being very useful considering that macOS tends to populate non-existent settings with values anyway. I don't see much utility in declaring a value in YAML, and then ignoring it in certain circumstances.