### PR TITLE
support for separators (multiple docs) in single yaml file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "testresult",
  "thiserror",
  "yaml-rust",
+ "yaml-split",
 ]
 
 [[package]]
@@ -1223,4 +1224,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yaml-split"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dab2bfe3b9aa09e8424e0e5139526c6a3857c4bd334d66b0453a357dd80fc58"
+dependencies = [
+ "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ shadow-rs = { version = "0.35.0", default-features = false }
 sysinfo = "0.31.4"
 thiserror = "1.0.63"
 yaml-rust = "0.4.5"
+yaml-split = "0.4.0"
 
 [dev-dependencies]
 testresult = "0.4.1"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ data:
 
     # Export photos in vCards
     ABIncludePhotosInVCard: true
+---
+# Multiple yaml docs in single file.
+description: Dock
+
+kill: ["Dock"]
+
+data:
+  # Automatically hide and show the Dock
+  com.apple.dock:
+    autohide: true
 ```
 
 You may also use full paths to `.plist` files instead of domain names. This is the only way to set values in /Library/Preferences/.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,4 +47,7 @@ pub enum DefaultsError {
 
     #[error("Eyre error.")]
     EyreError { source: color_eyre::Report },
+
+    #[error("failed to split YAML file {path}")]
+    YamlSplitError { path: Utf8PathBuf, source: yaml_split::YamlSplitError },
 }


### PR DESCRIPTION
Added ability to use single file for all kinds of defaults using `yaml_split::DocumentIterator` crate
Also reworked processing part a little, please take a look